### PR TITLE
Checked tag len

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,7 @@ keywords = ["index", "extension", "int-index", "array-index"]
 # Activate some additional operations that require nightly
 nightly = []
 alloc = []
+
+[[example]]
+name = "huffman-buffer"
+required-features = ["alloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ keywords = ["index", "extension", "int-index", "array-index"]
 [features]
 # Activate some additional operations that require nightly
 nightly = []
+alloc = []

--- a/examples/huffman-buffer.rs
+++ b/examples/huffman-buffer.rs
@@ -1,0 +1,162 @@
+use index_ext::tag::{Boxed, Constant, ConstantSource, ExactSize, Idx};
+
+const BUFFER_SIZE: usize = 4096;
+struct BufferSize4K;
+
+impl ConstantSource for BufferSize4K {
+    const LEN: usize = BUFFER_SIZE;
+}
+
+const LEN: ExactSize<Constant<BufferSize4K>> = Constant::EXACT_SIZE;
+
+type ParentId = Idx<usize, Constant<BufferSize4K>>;
+
+/// A 8-byte Huffman encoding tree.
+/// Each entry points to its is ensured to point into the `parents` buffer.
+struct HuffmanTree {
+    parents: Boxed<ParentId, Constant<BufferSize4K>>,
+    bytes: Boxed<u8, Constant<BufferSize4K>>,
+}
+
+fn main() {
+    let huffman = HuffmanTree::new();
+    let compare = Comparison::new();
+
+    let codes: Vec<_> = (0..BUFFER_SIZE).collect();
+
+    for _ in 0..1_000 {
+        for &code in &codes {
+            let _ = compare.code_of(code);
+        }
+    }
+    let start = std::time::Instant::now();
+    let mut side_effect = 0;
+    for _ in 0..1_000_000 {
+        for &code in &codes {
+            side_effect |= compare.code_of(code);
+        }
+    }
+    let duration = std::time::Instant::now()
+        .duration_since(start)
+        .as_secs_f32();
+    println!(
+        "With dynamically checked indices: {}s ({})",
+        duration, side_effect
+    );
+
+    let codes: Vec<_> = (0..BUFFER_SIZE)
+        .map(|i| LEN.len().index(i).unwrap())
+        .collect();
+
+    for _ in 0..1_000 {
+        for &code in &codes {
+            let _ = huffman.code_of(code);
+        }
+    }
+    let start = std::time::Instant::now();
+    let mut side_effect = 0;
+    for _ in 0..1_000_000 {
+        for &code in &codes {
+            side_effect |= huffman.code_of(code);
+        }
+    }
+    let duration = std::time::Instant::now()
+        .duration_since(start)
+        .as_secs_f32();
+    println!(
+        "With dynamically checked indices: {}s ({})",
+        duration, side_effect
+    );
+}
+
+/// An alternative, with standard checked indexing.
+struct Comparison {
+    parents: [usize; BUFFER_SIZE],
+    bytes: [u8; BUFFER_SIZE],
+}
+
+impl HuffmanTree {
+    pub fn new() -> Self {
+        let mut p: Vec<_> = generate_parent_indices()
+            .map(|idx| LEN.len().index(idx).unwrap())
+            .collect();
+
+        // Zero-extend.
+        let zero = LEN.len().index(0).unwrap();
+        p.resize(BUFFER_SIZE, zero);
+        let p = p.into_boxed_slice();
+
+        let mut b = vec![0; BUFFER_SIZE].into_boxed_slice();
+        for (p, b) in generate_bytes().zip(&mut b[..]) {
+            *b = p;
+        }
+
+        HuffmanTree {
+            parents: Boxed::new(p, LEN).unwrap_or_else(|_| panic!("Bad length of buffer")),
+            bytes: Boxed::new(b, LEN).unwrap_or_else(|_| panic!("Bad length of buffer")),
+        }
+    }
+
+    fn code_of(&self, start: ParentId) -> u64 {
+        let mut enc: u64 = 0;
+        let mut code = start;
+        while {
+            enc = (enc << 8) | u64::from(*self.bytes.get_safe(code));
+            let more = code.into_inner() > 255;
+            code = *self.parents.get_safe(code);
+            more
+        } {}
+        enc
+    }
+}
+
+impl Comparison {
+    pub fn new() -> Self {
+        let mut c = Comparison {
+            parents: [0; BUFFER_SIZE],
+            bytes: [0; BUFFER_SIZE],
+        };
+
+        for (p, b) in generate_parent_indices().zip(&mut c.parents[..]) {
+            *b = p;
+        }
+
+        for (p, b) in generate_bytes().zip(&mut c.bytes[..]) {
+            *b = p;
+        }
+
+        c
+    }
+
+    fn code_of(&self, start: usize) -> u64 {
+        let mut enc: u64 = 0;
+        let mut code = start;
+        while {
+            enc = (enc << 8) | u64::from(self.bytes[code]);
+            let more = code > 255;
+            code = self.parents[code];
+            more
+        } {}
+        enc
+    }
+}
+
+fn generate_parent_indices() -> impl Iterator<Item = usize> {
+    std::iter::repeat(0)
+        .take(256)
+        .chain((0..3).map(|i| std::iter::repeat(i).take(256)).flatten())
+        .chain({
+            (0..4)
+                .map(|i| std::iter::repeat(256 + i).take(256))
+                .flatten()
+        })
+        .chain({
+            (0..8)
+                .map(|i| std::iter::repeat(1024 + i).take(256))
+                .flatten()
+        })
+}
+
+fn generate_bytes() -> impl Iterator<Item = u8> {
+    std::iter::repeat((0..=255).into_iter()).flatten()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ mod sealed {
 #[cfg(feature = "nightly")]
 pub mod array;
 pub mod int;
+pub mod tag;
 
 /// A trait for integer based indices.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,8 @@
 //! `core` then this indirection would not be necessary and ergonomics would improve.
 #![no_std]
 #![cfg_attr(feature = "nightly", feature(const_generics))]
+#![cfg(feature = "alloc")]
+extern crate alloc;
 
 mod sealed {
     /// Seals the `Int` extension trait.

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -274,6 +274,11 @@ impl<T> ExactSize<T> {
     pub const unsafe fn from_len_untagged(bound: Len<T>) -> Self {
         ExactSize { inner: bound }
     }
+
+    /// Returns the length.
+    pub const fn get(&self) -> usize {
+        self.inner.len
+    }
 }
 
 impl<T: Tag> ExactSize<T> {

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -328,3 +328,59 @@ mod tests {
         assert_eq!(output, [3, 1, 1]);
     }
 }
+
+/// assertion macros are due to (c) theInkSquid (foobles)
+/// ```compile_fail
+/// use index_ext::tag;
+/// macro_rules! assert_is_covariant {
+///     (for[$($gen_params:tt)*] ($type_name:ty) over $lf:lifetime) => {
+///         #[allow(warnings)]
+///         const _: fn() = || {
+///             struct Cov<$lf, $($gen_params)*>($type_name);
+/// 
+///             fn test_cov<'__s, '__a: '__b, '__b, $($gen_params)*>(
+///                 subtype: &'__s Cov<'__a, $($gen_params)*>,
+///                 mut _supertype: &'__s Cov<'__b, $($gen_params)*>,
+///             ) {
+///                 _supertype = subtype;
+///             }
+///         };
+///     };
+/// 
+///     (($type_name:ty) over $lf:lifetime) => {
+///         assert_is_covariant!(for[] ($type_name) over $lf);
+///     };
+/// }
+///
+/// assert_is_covariant! {
+///     (tag::Len<'r>) over 'r
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use index_ext::tag;
+/// macro_rules! assert_is_contravariant {
+///     (for[$($gen_params:tt)*] ($type_name:ty) over $lf:lifetime) => {
+///         #[allow(warnings)]
+///         const _: fn() = || {
+///             struct Contra<$lf, $($gen_params)*>($type_name);
+/// 
+///             fn test_contra<'__s, '__a: '__b, '__b, $($gen_params)*>(
+///                 mut _subtype: &'__s Contra<'__a, $($gen_params)*>,
+///                 supertype: &'__s Contra<'__b, $($gen_params)*>,
+///             ) {
+///                 _subtype = supertype;
+///             }
+///         };
+///     };
+/// 
+///     (($type_name:ty) over $lf:lifetime) => {
+///         assert_is_contravariant!(for[] ($type_name) over $lf);
+///     };
+/// }
+///
+/// assert_is_contravariant! {
+///     (tag::Len<'r>) over 'r
+/// }
+/// ```
+extern {}

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -1,0 +1,64 @@
+//! Not quite dependent typing for eliding bounds checks.
+//!
+//! The main idea is to use lifetimes as a compile time tag to identify a particular exact slice
+//! without keeping a direct reference of it.
+use core::marker::PhantomData;
+
+/// The length of a particular slice.
+#[derive(Clone, Copy)]
+pub struct Len<'r> {
+    len: usize,
+    lifetime: PhantomData<&'r fn(&'r [()])>,
+}
+
+#[derive(Clone, Copy)]
+pub struct Idx<'r> {
+    idx: usize,
+    lifetime: PhantomData<&'r fn(&'r [()])>,
+}
+
+impl Len<'_> {
+    pub fn with<T, U>(
+        slice: &[T],
+        f: impl for<'r> FnOnce(Len<'r>, &'r [T]) -> U
+    ) -> U {
+        let len = Len {
+            len: slice.len(),
+            lifetime: PhantomData,
+        };
+
+        f(len, slice)
+    }
+
+    pub fn with_mut<T, U>(
+        slice: &mut [T],
+        f: impl for<'r> FnOnce(Len<'r>, &'r mut [T]) -> U
+    ) -> U {
+        let len = Len {
+            len: slice.len(),
+            lifetime: PhantomData,
+        };
+
+        f(len, slice)
+    }
+}
+
+impl<'slice> Len<'slice> {
+    pub fn index(&self, idx: usize) -> Option<Idx<'slice>> {
+        if self.len < idx {
+            Some(Idx { idx, lifetime: self.lifetime })
+        } else {
+            None
+        }
+    }
+}
+
+impl<'slice> Idx<'slice> {
+    pub fn get_ref<T>(self, slice: &'slice [T]) -> &'slice T {
+        unsafe { slice.get_unchecked(self.idx) }
+    }
+
+    pub fn get_mut<T>(self, slice: &'slice mut [T]) -> &'slice mut T {
+        unsafe { slice.get_unchecked_mut(self.idx) }
+    }
+}

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -1,64 +1,279 @@
 //! Not quite dependent typing for eliding bounds checks.
 //!
 //! The main idea is to use lifetimes as a compile time tag to identify a particular exact slice
-//! without keeping a direct reference of it.
+//! without keeping a direct reference of it. This means that you can not choose any of the
+//! lifetime parameters that you see in this module. Instead, you must be prepared to handle
+//! arbitrary lifetime which will make it opaque to you and the compiler. Each lifetime guarantees
+//! that all `Ref` and `Mut` with that exact lifetime are at least as long as all the sizes in
+//! `Len` structs of the same lifetime and each `Idx` is bounded by some `Len`. While this may seem
+//! very restrictive at first, it still allows you to pass information on a slice's length across
+//! function boundaries by explicitly mentioning the same lifetime twice. Additionally you're
+//! allowed some mutable operations on indices that can not exceed the original bounds.
+//!
+//! Use `with_ref` and `with_mut` as the main entry constructors.
 use core::marker::PhantomData;
+use core::num::NonZeroUsize;
 
-/// The length of a particular slice.
+/// Enter a region for soundly indexing a slice without bounds checks.
+///
+/// The supplied function gets a freshly constructed pair of corresponding slice reference and
+/// length tag. It has no control over the exact lifetime.
+pub fn with_ref<T, U>(
+    slice: &[T],
+    f: impl for<'r> FnOnce(Ref<'r, T>, Len<'r>) -> U
+) -> U {
+    let len = Len {
+        len: slice.len(),
+        lifetime: PhantomData,
+    };
+
+    let slice = Ref { slice };
+
+    f(slice, len)
+}
+
+/// Enter a region for soundly indexing a mutable slice without bounds checks.
+///
+/// The supplied function gets a freshly constructed pair of corresponding slice reference and
+/// length tag. It has no control over the exact lifetime.
+pub fn with_mut<T, U>(
+    slice: &mut [T],
+    f: impl for<'r> FnOnce(Mut<'r, T>, Len<'r>) -> U
+) -> U {
+    let len = Len {
+        len: slice.len(),
+        lifetime: PhantomData,
+    };
+
+    let slice = Mut { slice };
+
+    f(slice, len)
+}
+
+/// The length of a particular slice (or a number of slices).
+///
+/// The encapsulated length field is guaranteed to be at most the length of each of the slices with
+/// the exact same lifetime. This allows this instance to construct indices that are validated to
+/// be able to soundly access the slices without required any particular slice instance. In
+/// particular, the construct might happen by a numerical algorithm independent of the slices and
+/// across method bounds where the compiler's optimizer and inline pass is no longer aware of the
+/// connection and would otherwise insert another check when the slice is indexed later.
 #[derive(Clone, Copy)]
-pub struct Len<'r> {
+pub struct Len<'slice> {
     len: usize,
-    lifetime: PhantomData<&'r fn(&'r [()])>,
+    /// An invariant lifetime.
+    lifetime: PhantomData<&'slice fn(&'slice [()])>,
 }
 
+/// The length of a non-empty slice.
 #[derive(Clone, Copy)]
-pub struct Idx<'r> {
-    idx: usize,
-    lifetime: PhantomData<&'r fn(&'r [()])>,
+pub struct NonZeroLen<'slice> {
+    len: NonZeroUsize,
+    /// An invariant lifetime.
+    lifetime: PhantomData<&'slice fn(&'slice [()])>,
 }
 
-impl Len<'_> {
-    pub fn with<T, U>(
-        slice: &[T],
-        f: impl for<'r> FnOnce(Len<'r>, &'r [T]) -> U
-    ) -> U {
-        let len = Len {
-            len: slice.len(),
-            lifetime: PhantomData,
-        };
+/// A slice with a unique lifetime.
+///
+/// You can only construct this via [`Len::with_ref`].
+///
+/// [`Len::with_ref`]: struct.Len.html#method.with_ref
+#[derive(Clone, Copy)]
+pub struct Ref<'slice, T> {
+    slice: &'slice [T],
+}
 
-        f(len, slice)
-    }
+/// A mutable slice with a unique lifetime.
+///
+/// You can only construct this via [`Len::with_mut`].
+///
+/// [`Len::with_mut`]: struct.Len.html#method.with_mut
+pub struct Mut<'slice, T> {
+    slice: &'slice mut [T],
+}
 
-    pub fn with_mut<T, U>(
-        slice: &mut [T],
-        f: impl for<'r> FnOnce(Len<'r>, &'r mut [T]) -> U
-    ) -> U {
-        let len = Len {
-            len: slice.len(),
-            lifetime: PhantomData,
-        };
-
-        f(len, slice)
-    }
+/// A valid index for all slices of the same length.
+///
+/// While this has a generic parameter, you can only instantiate this type for specific types
+/// through one of the constructors of a corresponding [`Len]` struct.
+///
+/// [`Len`]: struct.Len.html
+#[derive(Clone, Copy)]
+pub struct Idx<'slice, I> {
+    idx: I,
+    /// An invariant lifetime.
+    lifetime: PhantomData<&'slice fn(&'slice [()])>,
 }
 
 impl<'slice> Len<'slice> {
-    pub fn index(&self, idx: usize) -> Option<Idx<'slice>> {
+    /// Returns the stored length.
+    pub fn get(self) -> usize {
+        self.len
+    }
+
+    /// Construct an index to a single element.
+    ///
+    /// This method return `Some` when the index is smaller than the length.
+    pub fn index(self, idx: usize) -> Option<Idx<'slice, usize>> {
         if self.len < idx {
             Some(Idx { idx, lifetime: self.lifetime })
         } else {
             None
         }
     }
-}
 
-impl<'slice> Idx<'slice> {
-    pub fn get_ref<T>(self, slice: &'slice [T]) -> &'slice T {
-        unsafe { slice.get_unchecked(self.idx) }
+    /// Construct an index to a range of element.
+    ///
+    /// This method return `Some` when the indices are ordered and `to` does not exceed the length.
+    pub fn range(self, from: usize, to: usize) -> Option<Idx<'slice, core::ops::Range<usize>>> {
+        if self.len < from && self.len < to && from <= to {
+            Some(Idx { idx: from..to, lifetime: self.lifetime })
+        } else {
+            None
+        }
     }
 
-    pub fn get_mut<T>(self, slice: &'slice mut [T]) -> &'slice mut T {
-        unsafe { slice.get_unchecked_mut(self.idx) }
+    /// Construct an index to a range from an element.
+    ///
+    /// This method return `Some` when `from` does not exceed the length.
+    pub fn range_from(self, from: usize) -> Option<Idx<'slice, core::ops::RangeFrom<usize>>> {
+        if self.len <= from {
+            Some(Idx { idx: from.., lifetime: self.lifetime })
+        } else {
+            None
+        }
+    }
+
+    /// Construct an index to a range up to an element.
+    ///
+    /// This method return `Some` when `to` does not exceed the length.
+    pub fn range_to(self, to: usize) -> Option<Idx<'slice, core::ops::RangeTo<usize>>> {
+        if self.len <= to {
+            Some(Idx { idx: ..to, lifetime: self.lifetime })
+        } else {
+            None
+        }
+    }
+
+    /// Construct an index to all elements.
+    ///
+    /// This method exists mostly for completeness sake. There is no bounds check when accessing a
+    /// complete slice with `..`.
+    pub fn range_full(self) -> Idx<'slice, core::ops::RangeFull> {
+        Idx { idx: .., lifetime: self.lifetime }
+    }
+}
+
+impl<'slice> NonZeroLen<'slice> {
+    /// Construct the length of a non-empty slice.
+    pub fn new(complete: Len<'slice>) -> Option<Self> {
+        let len = NonZeroUsize::new(complete.len)?;
+        Some(NonZeroLen { len, lifetime: complete.lifetime })
+    }
+
+    /// Construct an index to the first element of a non-empty slice.
+    pub fn first(self) -> Idx<'slice, usize> {
+        Idx { idx: 0, lifetime: self.lifetime }
+    }
+
+    /// Construct an index to the last element of a non-empty slice.
+    pub fn last(self) -> Idx<'slice, usize> {
+        Idx { idx: self.len.get() - 1, lifetime: self.lifetime }
+    }
+
+    /// Get the non-zero length.
+    pub fn get(self) -> NonZeroUsize {
+        self.len
+    }
+}
+
+impl<'slice> From<NonZeroLen<'slice>> for Len<'slice> {
+    fn from(from: NonZeroLen<'slice>) -> Self {
+        Len { len: from.len.get(), lifetime: from.lifetime }
+    }
+}
+
+impl<'slice, I> Idx<'slice, I> {
+    /// Get the inner index.
+    pub fn into_inner(self) -> I {
+        self.idx
+    }
+}
+
+impl<'slice> Idx<'slice, usize> {
+    pub fn saturating_sub(self, sub: usize) -> Self {
+        Idx { idx: self.idx.saturating_sub(sub), lifetime: self.lifetime }
+    }
+
+    pub fn truncate(self, min: usize) -> Self {
+        Idx { idx: self.idx.min(min), lifetime: self.lifetime }
+    }
+}
+
+impl<'slice, T> Ref<'slice, T> {
+    /// Index the slice unchecked but soundly.
+    pub fn get_safe<I: core::slice::SliceIndex<[T]>>(&self, index: Idx<'slice, I>) -> &I::Output {
+        unsafe { self.slice.get_unchecked(index.idx) }
+    }
+}
+
+impl<'slice, T> Mut<'slice, T> {
+    /// Index the slice unchecked but soundly.
+    pub fn get_safe<I: core::slice::SliceIndex<[T]>>(&self, index: Idx<'slice, I>) -> &I::Output {
+        unsafe { self.slice.get_unchecked(index.idx) }
+    }
+
+    /// Mutably index the slice unchecked but soundly.
+    pub fn get_safe_mut<I: core::slice::SliceIndex<[T]>>(&mut self, index: Idx<'slice, I>) -> &mut I::Output {
+        unsafe { self.slice.get_unchecked_mut(index.idx) }
+    }
+}
+
+impl<T> core::ops::Deref for Ref<'_, T> {
+    type Target = [T];
+    fn deref(&self) -> &[T] {
+        self.slice
+    }
+}
+
+impl<T> core::ops::Deref for Mut<'_, T> {
+    type Target = [T];
+    fn deref(&self) -> &[T] {
+        self.slice
+    }
+}
+
+impl<T> core::ops::DerefMut for Mut<'_, T> {
+    fn deref_mut(&mut self) -> &mut [T] {
+        self.slice
+    }
+}
+
+impl<'slice, T, I> core::ops::Index<Idx<'slice, I>> for Ref<'slice, T>
+where
+    I: core::slice::SliceIndex<[T]>
+{
+    type Output = I::Output;
+    fn index(&self, idx: Idx<'slice, I>) -> &Self::Output {
+        self.get_safe(idx)
+    }
+}
+
+impl<'slice, T, I> core::ops::Index<Idx<'slice, I>> for Mut<'slice, T>
+where
+    I: core::slice::SliceIndex<[T]>
+{
+    type Output = I::Output;
+    fn index(&self, idx: Idx<'slice, I>) -> &Self::Output {
+        self.get_safe(idx)
+    }
+}
+
+impl<'slice, T, I> core::ops::IndexMut<Idx<'slice, I>> for Mut<'slice, T>
+where
+    I: core::slice::SliceIndex<[T]>
+{
+    fn index_mut(&mut self, idx: Idx<'slice, I>) -> &mut Self::Output {
+        self.get_safe_mut(idx)
     }
 }


### PR DESCRIPTION
The main idea is to use lifetimes as a compile time tag to identify a particular exact slice
without keeping a direct reference of it. This means that you can not choose any of the
lifetime parameters that you see in this module. Instead, you must be prepared to handle
arbitrary lifetime which will make it opaque to you and the compiler. Each lifetime guarantees
that all `Ref` and `Mut` with that exact lifetime are at least as long as all the sizes in
`Len` structs of the same lifetime and each `Idx` is bounded by some `Len`. While this may seem
very restrictive at first, it still allows you to pass information on a slice's length across
function boundaries by explicitly mentioning the same lifetime twice. Additionally you're
allowed some mutable operations on indices that can not exceed the original bounds.